### PR TITLE
There was an unescaped opening bracket in a regular expression.

### DIFF
--- a/VSUnbindSourceControl/Program.cs
+++ b/VSUnbindSourceControl/Program.cs
@@ -118,7 +118,7 @@ namespace VSUnbindSourceControl
 
                 if (line_trimmed.StartsWith("GlobalSection(SourceCodeControl)") 
                     || line_trimmed.StartsWith("GlobalSection(TeamFoundationVersionControl)")
-                    || System.Text.RegularExpressions.Regex.IsMatch(line_trimmed, "GlobalSection(.*Version.*Control", System.Text.RegularExpressions.RegexOptions.IgnoreCase))
+                    || System.Text.RegularExpressions.Regex.IsMatch(line_trimmed, @"GlobalSection\(.*Version.*Control", System.Text.RegularExpressions.RegexOptions.IgnoreCase))
                 {
                     // this means we are starting a Source Control Section
                     // do not copy the line to output


### PR DESCRIPTION
There was an unescaped opening bracket in the regular expression used to identify source control GlobalSections within solution files - this is now escaped.
